### PR TITLE
Add example how to display scores

### DIFF
--- a/src/docs/leaderboard.md
+++ b/src/docs/leaderboard.md
@@ -42,7 +42,7 @@ When you create a score, the current user's id is automatically assigned to the 
 
 ```gdscript
 # Fetch the Gotm-registered user that created score1.
-var user: Gotmuser = yield(GotmUser.fetch(score1.user_id), "completed")
+var user: GotmUser = yield(GotmUser.fetch(score1.user_id), "completed")
 if user:
     # User is a registered Gotm user and has a display name.
     # Access it with the user.display_name field.
@@ -289,6 +289,25 @@ Scores created from any users are included in your fetches by default. Use `user
 
 ```gdscript
 top_leaderboard.user_id = "<A_USER_ID>"
+```
+
+# Display Scores
+
+One way to display the scores in your game is to build a string to display the list with the rank of the score, the user's name or "Guest" if the user is not registered, and the value of the score.  You can then display this string inside of a label.
+
+```gdscript
+var strLeaderboard = ""
+
+var top_scores = yield(top_leaderboard.get_scores(), "completed")
+	for score in top_scores:
+		var rank = yield(top_leaderboard.get_rank(score), "completed")
+		strLeaderboard += (str(rank) + ": ")
+		var user : GotmUser = yield(GotmUser.fetch(score.user_id), "completed")
+		if user:
+			strLeaderboard += (user.display_name + ("    "))
+		else:
+			strLeaderboard += "Guest    "
+		strLeaderboard += (str(score.value)+"\n")
 ```
 
 # Manage scores in the dashboard

--- a/src/docs/leaderboard.md
+++ b/src/docs/leaderboard.md
@@ -293,7 +293,7 @@ top_leaderboard.user_id = "<A_USER_ID>"
 
 # Display Scores
 
-One way to display the scores in your game is to build a string to display the list with the rank of the score, the user's name or "Guest" if the user is not registered, and the value of the score.  You can then display this string inside of a label.
+One way to display the scores in your game is to build a string to display the list with the rank of each score, the user's name or "Guest" if the user is not registered, and the value of the score.  You can then display this string inside of a label.
 
 ```gdscript
 var strLeaderboard = ""


### PR DESCRIPTION
Added an example of how to display scores with user names, if available.  This is something it took me a little while to figure out how to do.  Also fixed a small type error on the same page.